### PR TITLE
Include `ccall :jl_generating_output` in try block

### DIFF
--- a/src/PrecompileSignatures.jl
+++ b/src/PrecompileSignatures.jl
@@ -257,13 +257,13 @@ Precompile the concrete signatures in module `M`.
 """
 macro precompile_signatures(M::Symbol)
     esc(quote
-        if ccall(:jl_generating_output, Cint, ()) == 1
-            try
+        try
+            if ccall(:jl_generating_output, Cint, ()) == 1
                 $PrecompileSignatures._precompile_signatures($M)
-            catch e
-                msg = "Generating and including the `precompile` directives failed"
-                @warn msg exception=(e, catch_backtrace())
             end
+        catch e
+            msg = "Generating and including the `precompile` directives failed"
+            @warn msg exception=(e, catch_backtrace())
         end
     end)
 end


### PR DESCRIPTION
This guards against the situation where `:jl_generating_output` is removed in a future release

```julia
julia> ccall(:jl_asdfasdfasdf, Cint, ())
ERROR: could not load symbol "jl_asdfasdfasdf":
dlsym(RTLD_DEFAULT, jl_asdfasdfasdf): symbol not found
Stacktrace:
 [1] top-level scope
   @ ./REPL[1]:1

julia> try
           ccall(:jl_asdfasdfasdf, Cint, ())
       catch
           0
       end
0
```