### PR TITLE
Remove `Documenter` dep.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,11 +3,7 @@ uuid = "91cefc8d-f054-46dc-8f8c-26e11d7c5411"
 authors = ["Rik Huijzer <t.h.huijzer@rug.nl>"]
 version = "3.0.2"
 
-[deps]
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-
 [compat]
-Documenter = "0.27"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PrecompileSignatures"
 uuid = "91cefc8d-f054-46dc-8f8c-26e11d7c5411"
 authors = ["Rik Huijzer <t.h.huijzer@rug.nl>"]
-version = "3.0.2"
+version = "3.0.3"
 
 [compat]
 julia = "1.6"


### PR DESCRIPTION
Vendor the `submodules` function from there instead of import the package. Fixes #7.

The function hasn't really changed much in the years since I wrote so it's probably better to just vendor it here rather than pulling in the entire dep.